### PR TITLE
perf: stop using assert

### DIFF
--- a/src/charcodehash.ts
+++ b/src/charcodehash.ts
@@ -1,5 +1,3 @@
-import assert from "node:assert";
-
 /**
  * Hashes the given text into a number.
  *
@@ -11,9 +9,8 @@ export function charcodehash(source: string): number {
 
 	let value = 0;
 	for (let index = 0; index < sourceLength; ++index) {
-		const codePoint = source.codePointAt(index);
-		assert(codePoint);
-		value += codePoint * (index + 1);
+		// biome-ignore lint/style/noNonNullAssertion: index always in range
+		value += source.codePointAt(index)! * (index + 1);
 	}
 
 	return Math.round(value);


### PR DESCRIPTION
Using `assert` was unnecessary and a penalty for performance.